### PR TITLE
LUM-1441: Disable Full Fine Tuning on docs

### DIFF
--- a/fine-tuning.yml
+++ b/fine-tuning.yml
@@ -146,7 +146,7 @@ components:
           description: The name of the fine-tuning job
         type:
           type: string
-          enum: [ FULL, LORA, QLORA ]
+          enum: [ LORA, QLORA ]
           description: The type of fine-tuning job to run
 
     FineTuningJobResponse:
@@ -172,7 +172,7 @@ components:
           type: string
         type:
           type: string
-          enum: [ FULL, LORA, QLORA ]
+          enum: [ LORA, QLORA ]
         current_step:
           type: integer
         total_steps:


### PR DESCRIPTION
# Notes
Disable full fine tuning until below issue resolved

_Identify why multi-GPU full fine-tuning is not working and single-GPU full fine-tuning is not performing well compared to LoRA fine-tuning. Additionally, investigate performance discrepancies across different datasets and improve the configurability of prompt handling in the pipeline._